### PR TITLE
Fix typo in resolving merge conflict

### DIFF
--- a/notebooks/milestone1.ipynb
+++ b/notebooks/milestone1.ipynb
@@ -9,7 +9,7 @@
    ]
   },
   {
-   "cell_type": "code"
+   "cell_type": "code",
    "execution_count": 1,
    "id": "tracked-reason",
    "metadata": {},


### PR DESCRIPTION
A comma was deleted by mistake when resolving the merge conflict in the previous pull request, which caused the notebook failure. Please merge this one to fix it.